### PR TITLE
Rename `ebpf_execution_context` to `ebpf_state`

### DIFF
--- a/.github/workflows/run-execution-context-tests.yml
+++ b/.github/workflows/run-execution-context-tests.yml
@@ -1,4 +1,4 @@
-name: Run unit tests of execution context
+name: Run unit tests of ebpf_state
 
 on:
   push:
@@ -22,7 +22,7 @@ jobs:
     - name: Build targets
       run: |
         CC=clang-15 CXX=clang++-15 cmake -S. -Bbuild -DCMAKE_BUILD_TYPE:STRING=Release -G Ninja
-        CC=clang-15 CXX=clang++-15 cmake --build ./build --config Release --target ebpf_execution_context_test
+        CC=clang-15 CXX=clang++-15 cmake --build ./build --config Release --target ebpf_state_test
     - name: Run tests
       run: |
-        ./build/execution-test/ebpf_execution_context_test
+        ./build/execution-test/ebpf_state_test

--- a/README.md
+++ b/README.md
@@ -17,15 +17,15 @@ Add this directory into your CMake project, and links target `libebpf`. See `lib
 - `pip install -r requirements.txt`
 - `pytest`
 
-## How to run execution context tests?
-- Build CMake target `ebpf_execution_context_test`
-- Run `./build/execution-test/ebpf_execution_context_test`
+## How to run ebpf_state tests?
+- Build CMake target `ebpf_state_test`
+- Run `./build/execution-test/ebpf_state_test`
 
-## Notes on ebpf_execution_context
+## Notes on ebpf_state
 
-`ebpf_vm` is just a virtual machine, it doesn't have ability to manage or access maps. We provide `ebpf_execution_context` for such operations. You may create a `ebpf_execution_context` and create maps in it. Before running your ebpf programs using ebpf_vm, you should call `ebpf_execution_context__setup_internal_helpers` to setup internal helpers (such as `bpf_map_lookup_elem`) to the vm, and should also point `ebpf_execution_context__thread_global_context` to the context you want to use. Then you can run your ebpf programs with access to the context.
+`ebpf_vm` is just a virtual machine, it doesn't have ability to manage or access maps. We provide `ebpf_state` for such operations. You may create a `ebpf_state` and create maps in it. Before running your ebpf programs using ebpf_vm, you should call `ebpf_state__setup_internal_helpers` to setup internal helpers (such as `bpf_map_lookup_elem`) to the vm, and should also point `ebpf_state__thread_global_context` to the context you want to use. Then you can run your ebpf programs with access to the context.
 
 ## Notes on FFI
-You may call `ebpf_execution_context__register_ffi_function` to register a FFI function. FFI functions are type safe, which means that it always accept int64_t and returns int64_t at the bpf side, but it would convert the received argument to the proper types when calling the FFI function.
-You may use some helper macros for FFI callling in the BPF side. see `libebpf_ffi.bpf.c` for details.
-You may use `LIBEBPF_EXPORT_FUNCTION_ARG[N]` (where `[N]` is an integer range 0 to 6) to export a function and automatically registers when the execution context was created. This macro is only applicatable in the target `libebpf`, since it needs a modified link process
+You may call `ebpf_state__register_ffi_function` to register a FFI function. FFI functions are type safe, which means that it always accept int64_t and returns int64_t at the bpf side, but it would convert the received argument to the proper types when calling the FFI function.
+You may use some helper macros for FFI callling in the BPF side. see `libebpf_ffi.bpf.h` for details.
+You may use `LIBEBPF_EXPORT_FUNCTION_ARG[N]` (where `[N]` is an integer range 0 to 6) to export a function and automatically registers when the ebpf_state was created. This macro is only applicatable in the target `libebpf`, since it needs a modified link process

--- a/execution-test/CMakeLists.txt
+++ b/execution-test/CMakeLists.txt
@@ -1,24 +1,24 @@
 add_subdirectory(catch2)
 
 add_executable(
-    ebpf_execution_context_test
+    ebpf_state_test
     ./test_map.cpp
     ./test_with_ebpf.cpp
     ./test_ffi.cpp
 )
 
-add_dependencies(ebpf_execution_context_test
+add_dependencies(ebpf_state_test
     Catch2
     libebpf
 )
-target_link_libraries(ebpf_execution_context_test
+target_link_libraries(ebpf_state_test
     PRIVATE
     libebpf
     Catch2::Catch2WithMain
 )
 
-target_include_directories(ebpf_execution_context_test PRIVATE ${Catch2_INCLUDE} ${CMAKE_CURRENT_SOURCE_DIR}/../src)
+target_include_directories(ebpf_state_test PRIVATE ${Catch2_INCLUDE} ${CMAKE_CURRENT_SOURCE_DIR}/../src)
 
-set_target_properties(ebpf_execution_context_test PROPERTIES CXX_STANDARD 20 LINKER_LANGUAGE CXX) 
-target_compile_options(ebpf_execution_context_test PRIVATE -fsanitize=address -fsanitize=undefined -D_LIBEBPF_UNIT_TEST)
-target_link_options(ebpf_execution_context_test PRIVATE -fsanitize=address -fsanitize=undefined)
+set_target_properties(ebpf_state_test PROPERTIES CXX_STANDARD 20 LINKER_LANGUAGE CXX) 
+target_compile_options(ebpf_state_test PRIVATE -fsanitize=address -fsanitize=undefined -D_LIBEBPF_UNIT_TEST)
+target_link_options(ebpf_state_test PRIVATE -fsanitize=address -fsanitize=undefined)

--- a/execution-test/test_ffi.cpp
+++ b/execution-test/test_ffi.cpp
@@ -18,29 +18,29 @@ static uint64_t uint64_plus(uint64_t a, uint64_t b) {
     return a + b;
 }
 TEST_CASE("Test FFI calls, without eBPF program") {
-    std::unique_ptr<ebpf_execution_context_t, decltype(&ebpf_execution_context__destroy)> ctx(ebpf_execution_context__create(),
-                                                                                              ebpf_execution_context__destroy);
+    std::unique_ptr<ebpf_state_t, decltype(&ebpf_state__destroy)> ctx(ebpf_state__create(),
+                                                                                              ebpf_state__destroy);
     REQUIRE(ctx != nullptr);
-    ebpf_execution_context__thread_global_context = ctx.get();
+    ebpf_state__thread_global_state = ctx.get();
     std::unique_ptr<ebpf_vm_t, decltype(&ebpf_vm_destroy)> vm(ebpf_vm_create(), ebpf_vm_destroy);
     REQUIRE(vm != nullptr);
-    ebpf_execution_context__setup_internal_helpers(vm.get());
+    ebpf_state__setup_internal_helpers(vm.get());
     int uint32_plus_id;
     {
         enum libebpf_ffi_type args[6] = { ARG_UINT32, ARG_UINT32, ARG_VOID, ARG_VOID, ARG_VOID, ARG_VOID };
-        uint32_plus_id = ebpf_execution_context__register_ffi_function(ctx.get(), (void *)&uint32_plus, "uint32_plus", args, ARG_UINT32);
+        uint32_plus_id = ebpf_state__register_ffi(ctx.get(), (void *)&uint32_plus, "uint32_plus", args, ARG_UINT32);
         REQUIRE(uint32_plus_id >= 0);
     }
     int uint64_plus_id;
     {
         enum libebpf_ffi_type args[6] = { ARG_UINT64, ARG_UINT64, ARG_VOID, ARG_VOID, ARG_VOID, ARG_VOID };
-        uint64_plus_id = ebpf_execution_context__register_ffi_function(ctx.get(), (void *)&uint64_plus, "uint64_plus", args, ARG_UINT64);
+        uint64_plus_id = ebpf_state__register_ffi(ctx.get(), (void *)&uint64_plus, "uint64_plus", args, ARG_UINT64);
         REQUIRE(uint64_plus_id >= 0);
     }
     int int32_plus_id;
     {
         enum libebpf_ffi_type args[6] = { ARG_INT32, ARG_INT32, ARG_VOID, ARG_VOID, ARG_VOID, ARG_VOID };
-        int32_plus_id = ebpf_execution_context__register_ffi_function(ctx.get(), (void *)&int32_plus, "int32_plus", args, ARG_INT32);
+        int32_plus_id = ebpf_state__register_ffi(ctx.get(), (void *)&int32_plus, "int32_plus", args, ARG_INT32);
         REQUIRE(int32_plus_id >= 0);
     }
     auto libebpf_ffi_lookup_by_name = [&](const char *name) -> int {

--- a/include/libebpf_execution.h
+++ b/include/libebpf_execution.h
@@ -7,41 +7,40 @@ extern "C" {
 #endif
 
 /**
- * @brief Opaque type for an execution context.
- * Execution context provides interfaces to create & operate on maps, defining FFI interfaces, and run ebpf programs using ebpf_vm. eBPF programs
- * executed through an execution context could use helpers related to maps and FFI.
+ * @brief Opaque type for an ebpf_state.
+ * ebpf_state provides interfaces to create & operate on maps, defining FFI interfaces, and provides helpers for ebpf_vm to do these operations.
  */
-struct ebpf_execution_context;
+struct ebpf_state;
 
-typedef struct ebpf_execution_context ebpf_execution_context_t;
+typedef struct ebpf_state ebpf_state_t;
 
 /**
  * @brief Global context for the current thread. You must set it before run your ebpf program, if you want to use features provided by
- * ebpf_execution_context
+ * ebpf_state
  *
  */
-extern __thread ebpf_execution_context_t *ebpf_execution_context__thread_global_context;
+extern __thread ebpf_state_t *ebpf_state__thread_global_state;
 
 /**
- * @brief Create an execution context
+ * @brief Create an ebpf_state
  *
- * @return ebpf_execution_context_t* A pointer to the context if succeeded. NULL if failed. Call ebpf_error_string to get error details.
+ * @return ebpf_state_t* A pointer to the context if succeeded. NULL if failed. Call ebpf_error_string to get error details.
  */
-ebpf_execution_context_t *ebpf_execution_context__create();
+ebpf_state_t *ebpf_state__create();
 
 /**
- * @brief Destroy the execution context
+ * @brief Destroy the ebpf_state
  *
  * @param ctx Pointer to the context
  */
-void ebpf_execution_context__destroy(ebpf_execution_context_t *ctx);
+void ebpf_state__destroy(ebpf_state_t *ctx);
 
 /**
- * @brief Setup helpers provided by ebpf_execution_context for the given ebpf_vm
+ * @brief Setup helpers provided by ebpf_state for the given ebpf_vm
  *
  * @param vm The vm instance
  */
-void ebpf_execution_context__setup_internal_helpers(ebpf_vm_t *vm);
+void ebpf_state__setup_internal_helpers(ebpf_vm_t *vm);
 #ifdef __cplusplus
 }
 #endif

--- a/include/libebpf_ffi.h
+++ b/include/libebpf_ffi.h
@@ -64,7 +64,7 @@ struct libebpf_ffi_function {
  * @param return_value_type Return type of the given FFI function
  * @return Negative value if failed. Otherwise the function ID
  */
-int ebpf_execution_context__register_ffi_function(ebpf_execution_context_t *ctx, void *func, const char *name,
+int ebpf_state__register_ffi(ebpf_state_t *ctx, void *func, const char *name,
                                                   const enum libebpf_ffi_type arg_types[6], enum libebpf_ffi_type return_value_type);
 #ifdef __cplusplus
 }

--- a/include/libebpf_map.h
+++ b/include/libebpf_map.h
@@ -12,7 +12,7 @@ extern "C" {
  * All maps are ensured to be thread safe. Locks are spin lock.
  * EBPF_MAP_TYPE_HASH - Hashmap for storing fixed-size (key, value) pairs
  * BPF_MAP_TYPE_ARRAY - Array for storing indexed values
- * BPF_MAP_TYPE_RINGBUF - Ringbuf map, with which eBPF programs could send data to ebpf_execution_context. Users could call a specified function to
+ * BPF_MAP_TYPE_RINGBUF - Ringbuf map, with which eBPF programs could send data to ebpf_state. Users could call a specified function to
  * retrive data.
  */
 enum ebpf_map_type {
@@ -56,14 +56,14 @@ struct ebpf_map_attr {
 };
 
 /**
- * @brief Create a map in the specified execution context
+ * @brief Create a map in the specified ebpf_state
  *
  * @param ctx The context
  * @param attr Attributes of the map
  * @param map_name Name of the map
  * @return int A non-negative map id if succeeded, otherwise a negative number. See ebpf_error_string for error details.
  */
-int ebpf_execution_context__map_create(ebpf_execution_context_t *ctx, const char *map_name, struct ebpf_map_attr *attr);
+int ebpf_state__map_create(ebpf_state_t *ctx, const char *map_name, struct ebpf_map_attr *attr);
 
 /**
  * @brief Destroy a specified map
@@ -72,7 +72,7 @@ int ebpf_execution_context__map_create(ebpf_execution_context_t *ctx, const char
  * @param map_id ID of the map
  * @return int 0 if succeeded. Otherwise failed.
  */
-int ebpf_execution_context__map_destroy(ebpf_execution_context_t *ctx, int map_id);
+int ebpf_state__map_destroy(ebpf_state_t *ctx, int map_id);
 
 /**
  * @brief Lookup a key in a certain map
@@ -83,7 +83,7 @@ int ebpf_execution_context__map_destroy(ebpf_execution_context_t *ctx, int map_i
  * @param value Buffer to the value. Must be in size of at least value_size
  * @return int 0 if succeeded, and value buffer will be updated. Otherwise failed.
  */
-int ebpf_execution_context__map_elem_lookup(ebpf_execution_context_t *ctx, int map_id, const void *key, void *value);
+int ebpf_state__map_elem_lookup(ebpf_state_t *ctx, int map_id, const void *key, void *value);
 
 /**
  * @brief Update a (key, value) pair in a certain map
@@ -95,7 +95,7 @@ int ebpf_execution_context__map_elem_lookup(ebpf_execution_context_t *ctx, int m
  * @param flags Map-specified flags
  * @return int 0 if succeeded, otherwise failed.
  */
-int ebpf_execution_context__map_elem_update(ebpf_execution_context_t *ctx, int map_id, const void *key, const void *value, uint64_t flags);
+int ebpf_state__map_elem_update(ebpf_state_t *ctx, int map_id, const void *key, const void *value, uint64_t flags);
 
 /**
  * @brief Delete an element from the map
@@ -105,7 +105,7 @@ int ebpf_execution_context__map_elem_update(ebpf_execution_context_t *ctx, int m
  * @param key Buffer to the key
  * @return int 0 if succeeded, otherwise failed
  */
-int ebpf_execution_context__map_elem_delete(ebpf_execution_context_t *ctx, int map_id, const void *key);
+int ebpf_state__map_elem_delete(ebpf_state_t *ctx, int map_id, const void *key);
 
 /**
  * @brief Get the next key after the given key
@@ -116,7 +116,7 @@ int ebpf_execution_context__map_elem_delete(ebpf_execution_context_t *ctx, int m
  * @param next_key Buffer to store the nexy key
  * @return int -ENOENT if key is the last key. Other negative values mean an error. Positive if succeeded
  */
-int ebpf_execution_context__map_get_next_key(ebpf_execution_context_t *ctx, int map_id, const void *key, void *next_key);
+int ebpf_state__map_get_next_key(ebpf_state_t *ctx, int map_id, const void *key, void *next_key);
 
 /**
  * @brief Get the opaque pointer to the private data of a ringbuf map. Useful if you want to call ringbuf_map_* functions
@@ -125,7 +125,7 @@ int ebpf_execution_context__map_get_next_key(ebpf_execution_context_t *ctx, int 
  * @param map_id ID of the map
  * @return struct ringbuf_map_private_data* the pointer if succeeded, otherwise NULL
  */
-struct ringbuf_map_private_data *ebpf_execution_context__get_ringbuf_map_private_data(ebpf_execution_context_t *ctx, int map_id);
+struct ringbuf_map_private_data *ebpf_state__get_ringbuf_map_private_data(ebpf_state_t *ctx, int map_id);
 
 #ifdef __cplusplus
 }

--- a/src/libebpf_execution_helpers.c
+++ b/src/libebpf_execution_helpers.c
@@ -13,7 +13,7 @@
 #define MAP_FD(ptr) (int)(ptr >> 32)
 
 static uint64_t bpf_map_lookup_elem(uint64_t map, uint64_t key, uint64_t _1, uint64_t _2, uint64_t _3) {
-    ebpf_execution_context_t *ctx = ebpf_execution_context__thread_global_context;
+    ebpf_state_t *ctx = ebpf_state__thread_global_state;
     int fd = MAP_FD(map);
     if (fd >= 0 && fd <= LIBEBPF_MAX_MAP_COUNT && ctx->maps[fd]) {
         return (uintptr_t)ctx->maps[fd]->ops->elem_lookup_from_helper(ctx->maps[fd], (const void *)(uintptr_t)key);
@@ -24,7 +24,7 @@ static uint64_t bpf_map_lookup_elem(uint64_t map, uint64_t key, uint64_t _1, uin
 }
 
 static uint64_t bpf_map_update_elem(uint64_t map, uint64_t key, uint64_t value, uint64_t flags, uint64_t _1) {
-    ebpf_execution_context_t *ctx = ebpf_execution_context__thread_global_context;
+    ebpf_state_t *ctx = ebpf_state__thread_global_state;
     int fd = MAP_FD(map);
     if (fd >= 0 && fd <= LIBEBPF_MAX_MAP_COUNT && ctx->maps[fd]) {
         return (uintptr_t)ctx->maps[fd]->ops->elem_update(ctx->maps[fd], (const void *)(uintptr_t)key, (const void *)(uintptr_t)value, 0);
@@ -34,7 +34,7 @@ static uint64_t bpf_map_update_elem(uint64_t map, uint64_t key, uint64_t value, 
     }
 }
 static uint64_t bpf_map_delete_elem(uint64_t map, uint64_t key, uint64_t _1, uint64_t _2, uint64_t _3) {
-    ebpf_execution_context_t *ctx = ebpf_execution_context__thread_global_context;
+    ebpf_state_t *ctx = ebpf_state__thread_global_state;
     int fd = MAP_FD(map);
     if (fd >= 0 && fd <= LIBEBPF_MAX_MAP_COUNT && ctx->maps[fd]) {
         return (uintptr_t)ctx->maps[fd]->ops->elem_delete(ctx->maps[fd], (const void *)(uintptr_t)key);
@@ -44,7 +44,7 @@ static uint64_t bpf_map_delete_elem(uint64_t map, uint64_t key, uint64_t _1, uin
     }
 }
 static uint64_t bpf_ringbuf_reserve(uint64_t map, uint64_t size, uint64_t flags, uint64_t _1, uint64_t _2) {
-    ebpf_execution_context_t *ctx = ebpf_execution_context__thread_global_context;
+    ebpf_state_t *ctx = ebpf_state__thread_global_state;
     int fd = MAP_FD(map);
     if (fd >= 0 && fd <= LIBEBPF_MAX_MAP_COUNT && ctx->maps[fd]) {
         struct ebpf_map *map = ctx->maps[fd];
@@ -63,7 +63,7 @@ static uint64_t bpf_ringbuf_reserve(uint64_t map, uint64_t size, uint64_t flags,
 static uint64_t bpf_ringbuf_submit(uint64_t buf, uint64_t flags, uint64_t _1, uint64_t _2, uint64_t _3) {
     int32_t *ptr = (int32_t *)(uintptr_t)buf;
     int fd = ptr[-1];
-    ebpf_execution_context_t *ctx = ebpf_execution_context__thread_global_context;
+    ebpf_state_t *ctx = ebpf_state__thread_global_state;
 
     if (fd >= 0 && fd <= LIBEBPF_MAX_MAP_COUNT && ctx->maps[fd]) {
         struct ebpf_map *map = ctx->maps[fd];
@@ -78,7 +78,7 @@ static uint64_t bpf_ringbuf_submit(uint64_t buf, uint64_t flags, uint64_t _1, ui
 static uint64_t bpf_ringbuf_discard(uint64_t buf, uint64_t flags, uint64_t _1, uint64_t _2, uint64_t _3) {
     int32_t *ptr = (int32_t *)(uintptr_t)buf;
     int fd = ptr[-1];
-    ebpf_execution_context_t *ctx = ebpf_execution_context__thread_global_context;
+    ebpf_state_t *ctx = ebpf_state__thread_global_state;
 
     if (fd >= 0 && fd <= LIBEBPF_MAX_MAP_COUNT && ctx->maps[fd]) {
         struct ebpf_map *map = ctx->maps[fd];
@@ -92,7 +92,7 @@ static uint64_t bpf_ringbuf_discard(uint64_t buf, uint64_t flags, uint64_t _1, u
 }
 
 static uint64_t map_by_fd(int fd) {
-    ebpf_execution_context_t *ctx = ebpf_execution_context__thread_global_context;
+    ebpf_state_t *ctx = ebpf_state__thread_global_state;
     if (fd >= 0 && fd <= LIBEBPF_MAX_MAP_COUNT && ctx->maps[fd]) {
         return ((uint64_t)fd) << 32;
     } else {
@@ -102,7 +102,7 @@ static uint64_t map_by_fd(int fd) {
 }
 static char *map_val(uint64_t map_ptr) {
     int fd = MAP_FD(map_ptr);
-    ebpf_execution_context_t *ctx = ebpf_execution_context__thread_global_context;
+    ebpf_state_t *ctx = ebpf_state__thread_global_state;
     if (fd >= 0 && fd <= LIBEBPF_MAX_MAP_COUNT && ctx->maps[fd]) {
         if (ctx->maps[fd]->attr.type == EBPF_MAP_TYPE_ARRAY) {
             struct ebpf_map *map = ctx->maps[fd];
@@ -119,7 +119,7 @@ static char *map_val(uint64_t map_ptr) {
 }
 
 static uint64_t helper_libebpf_ffi_lookup_by_name(uint64_t name, uint64_t _1, uint64_t _2, uint64_t _3, uint64_t _4) {
-    ebpf_execution_context_t *ctx = ebpf_execution_context__thread_global_context;
+    ebpf_state_t *ctx = ebpf_state__thread_global_state;
     struct libebpf_ffi_name_entry entry = { .name = (const char *)name, .id = -1 };
     const struct libebpf_ffi_name_entry *ent = hashmap_get(ctx->ffi_func_name_hashmap, &entry, NULL);
     if (ent == NULL) {
@@ -214,7 +214,7 @@ static int64_t store_argument_to_int64(enum libebpf_ffi_type type, union libebpf
 
 static uint64_t helper_libebpf_ffi_call(uint64_t func_id, uint64_t args, uint64_t _1, uint64_t _2, uint64_t _3) {
     int id = func_id;
-    ebpf_execution_context_t *ctx = ebpf_execution_context__thread_global_context;
+    ebpf_state_t *ctx = ebpf_state__thread_global_state;
 
     if (id < 0 || id > LIBEBPF_MAX_FFI_COUNT || !ctx->ffi_funcs[id].ptr) {
         ebpf_set_error_string("Invalid ffi function id: %d", id);
@@ -231,7 +231,7 @@ static uint64_t helper_libebpf_ffi_call(uint64_t func_id, uint64_t args, uint64_
     return store_argument_to_int64(ent->return_value_type, result);
 }
 
-void ebpf_execution_context__setup_internal_helpers(ebpf_vm_t *vm) {
+void ebpf_state__setup_internal_helpers(ebpf_vm_t *vm) {
     ebpf_vm_set_ld64_helpers(vm, map_by_fd, NULL, map_val, NULL, NULL);
     ebpf_vm_register_external_helper(vm, 1, "bpf_map_lookup_elem", bpf_map_lookup_elem);
     ebpf_vm_register_external_helper(vm, 2, "bpf_map_update_elem", bpf_map_update_elem);

--- a/src/libebpf_execution_internal.h
+++ b/src/libebpf_execution_internal.h
@@ -28,7 +28,7 @@ struct ebpf_map_ops {
     void *(*elem_lookup_from_helper)(struct ebpf_map *map, const void *key);
 };
 
-struct ebpf_execution_context {
+struct ebpf_state {
     struct ebpf_map **maps;
     ebpf_spinlock_t map_alloc_lock;
     struct ebpf_map_ops map_ops[(int)__MAX_EBPF_MAP_TYPE];


### PR DESCRIPTION
`ebpf_execution_context` is too long, so make it shorter